### PR TITLE
Enable/Disable Left/Right Swipe Implemented.

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemCode.bind
@@ -23,6 +23,8 @@
                     RightForeground ="@[RightForeground:Brush:White]"
                     ActivationWidth="@[ActivationWidth:Slider:100:50-250]"
                     MouseSlidingEnabled="@[MouseSlidingEnabled:Bool:true]"
+                    IsSwipeRightEnabled="@[IsRightSwipeEnabled:Bool:true]"
+                    IsSwipeLeftEnabled="@[IsLeftSwipeEnabled:Bool:true]"
                     LeftCommand="{x:Bind ToggleFavorite}"
                     RightCommandRequested="SlidableListItem_RightCommandActivated">
                 <Grid Height="110" Background="Gray">

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemPage.xaml
@@ -18,6 +18,8 @@
                                        LeftLabel="{Binding DataContext.LeftLabel.Value, ElementName=Root, Mode=OneWay}" 
                                        RightLabel="{Binding DataContext.RightLabel.Value, ElementName=Root, Mode=OneWay}" 
                                        HorizontalAlignment="Stretch"
+                                       IsRightSwipeEnabled="{Binding DataContext.IsRightSwipeEnabled.Value, ElementName=Root, Mode=OneWay}"
+                                       IsLeftSwipeEnabled="{Binding DataContext.IsLeftSwipeEnabled.Value, ElementName=Root, Mode=OneWay}"
                                        LeftBackground="{Binding DataContext.LeftBackground.Value, ElementName=Root, Mode=OneWay}" 
                                        RightBackground="{Binding DataContext.RightBackground.Value, ElementName=Root, Mode=OneWay}"
                                        LeftForeground ="{Binding DataContext.LeftForeground.Value, ElementName=Root, Mode=OneWay}" 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -31,6 +31,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public class SlidableListItem : ContentControl
     {
         /// <summary>
+        /// Indetifies the <see cref="IsLeftSwipeEnabled"/> property
+        /// </summary>
+        public static readonly DependencyProperty IsLeftSwipeEnabledProperty =
+            DependencyProperty.Register("IsLeftSwipeEnabled", typeof(bool), typeof(SlidableListItem), new PropertyMetadata(true));
+
+        /// <summary>
+        /// Indetifies the <see cref="IsRightSwipeEnabled"/> property
+        /// </summary>
+        public static readonly DependencyProperty IsRightSwipeEnabledProperty =
+            DependencyProperty.Register("IsRightSwipeEnabled", typeof(bool), typeof(SlidableListItem), new PropertyMetadata(true));
+
+        /// <summary>
         /// Indetifies the <see cref="ActivationWidth"/> property
         /// </summary>
         public static readonly DependencyProperty ActivationWidthProperty =
@@ -225,16 +237,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void ContentGrid_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
         {
-            if (!MouseSlidingEnabled && e.PointerDeviceType == PointerDeviceType.Mouse)
-            {
+            if ((!MouseSlidingEnabled && e.PointerDeviceType == PointerDeviceType.Mouse) || (!IsRightSwipeEnabled && !IsLeftSwipeEnabled))
+            { // If mouse sliding is not enabled OR both swipe options disabled, don't measure anything.
                 return;
             }
 
-            _transform.TranslateX += e.Delta.Translation.X;
-            var abs = Math.Abs(_transform.TranslateX);
+            var abs = Math.Abs(_transform.TranslateX + e.Delta.Translation.X);
 
-            if (_transform.TranslateX > 0)
-            {
+            if (IsRightSwipeEnabled && e.Delta.Translation.X > 0)
+            { // Swiping from left to right.
+                _transform.TranslateX += e.Delta.Translation.X;
                 if (_commandContainer != null)
                 {
                     _commandContainer.Background = LeftBackground as SolidColorBrush;
@@ -252,8 +264,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     _leftCommandTransform.TranslateX = 20;
                 }
             }
-            else
-            {
+            else if (IsLeftSwipeEnabled && e.Delta.Translation.X < 0)
+            { // Swiping from right to left.
+                _transform.TranslateX += e.Delta.Translation.X;
                 if (_commandContainer != null)
                 {
                     _commandContainer.Background = RightBackground as SolidColorBrush;
@@ -271,6 +284,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     _rightCommandTransform.TranslateX = -20;
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether swiping left is enabled or not.
+        /// </summary>
+        public bool IsLeftSwipeEnabled
+        {
+            get { return (bool)GetValue(IsLeftSwipeEnabledProperty); }
+            set { SetValue(IsLeftSwipeEnabledProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether swiping right is enabled or not.
+        /// </summary>
+        public bool IsRightSwipeEnabled
+        {
+            get { return (bool)GetValue(IsRightSwipeEnabledProperty); }
+            set { SetValue(IsRightSwipeEnabledProperty, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
IsLeftSwipeEnabled and IsRightSwipeEnabled dependency properties now
controls wheter users can swipe the items to left or right.

Fixes #156